### PR TITLE
Clean up code base

### DIFF
--- a/ccat.go
+++ b/ccat.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"syscall"
+
+	"github.com/mattn/go-isatty"
+)
+
+func CCat(fname string, colorDefs ColorDefs) error {
+	var r io.Reader
+
+	if fname == readFromStdin {
+		// scanner.Scanner from text/scanner couldn't detect EOF
+		// if the io.Reader is os.Stdin
+		// see https://github.com/golang/go/issues/10735
+		b, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		r = bytes.NewReader(b)
+	} else {
+		file, err := os.Open(fname)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		r = file
+	}
+
+	var err error
+	if isatty.IsTerminal(uintptr(syscall.Stdout)) {
+		err = CPrint(r, os.Stdout, colorDefs)
+	} else {
+		_, err = io.Copy(os.Stdout, r)
+	}
+
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -1,22 +1,16 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
-	"io"
-	"io/ioutil"
 	"log"
 	"os"
-	"syscall"
 
 	"github.com/jingweno/ccat/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/jingweno/ccat/Godeps/_workspace/src/github.com/mattn/go-colorable"
-	"github.com/jingweno/ccat/Godeps/_workspace/src/github.com/mattn/go-isatty"
 )
 
-var (
-	stdout = colorable.NewColorableStdout()
-)
+const readFromStdin = "-"
+
+var stdout = colorable.NewColorableStdout()
 
 func main() {
 	app := cli.NewApp()
@@ -50,52 +44,13 @@ func runCCat(c *cli.Context) {
 	fnames := c.Args()
 	// if there's no args, read from stdin
 	if len(fnames) == 0 {
-		fnames = []string{"-"}
+		fnames = []string{readFromStdin}
 	}
 
 	for _, fname := range fnames {
-		err := ccat(fname, colorDefs)
+		err := CCat(fname, colorDefs)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
-}
-
-func ccat(fname string, colorDefs ColorDefs) error {
-	var r io.Reader
-
-	if fname == "-" {
-		// scanner.Scanner from text/scanner couldn't detect EOF
-		// if the io.Reader is os.Stdin
-		// see https://github.com/golang/go/issues/10735
-		b, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			return err
-		}
-
-		r = bytes.NewReader(b)
-	} else {
-		file, err := os.Open(fname)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		r = file
-	}
-
-	r = bufio.NewReader(r)
-	var err error
-	if isatty.IsTerminal(uintptr(syscall.Stdout)) {
-		var buf bytes.Buffer
-		err = AsCCat(r, &buf, colorDefs)
-		if err != nil {
-			return err
-		}
-
-		_, err = stdout.Write(buf.Bytes())
-	} else {
-		_, err = io.Copy(os.Stdout, r)
-	}
-
-	return err
 }

--- a/printer.go
+++ b/printer.go
@@ -39,7 +39,7 @@ var DarkColorDefs = ColorDefs{
 	syntaxhighlight.Decimal:       "blue",
 }
 
-func AsCCat(r io.Reader, w io.Writer, cdefs ColorDefs) error {
+func CPrint(r io.Reader, w io.Writer, cdefs ColorDefs) error {
 	return syntaxhighlight.Print(newScanner(r), w, Printer{cdefs})
 }
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -9,7 +9,7 @@ func TestAsCCat(t *testing.T) {
 	r := bytes.NewBufferString("hello")
 	var w bytes.Buffer
 
-	err := AsCCat(r, &w, LightColorDefs)
+	err := CPrint(r, &w, LightColorDefs)
 	if err != nil {
 		t.Errorf("error should be nil, but it's %s", err)
 	}


### PR DESCRIPTION
* Move `func CCat` to a separate file
* Print directly to `os.Stdout` instead of buffering in bytes
* Rename `AsCCat` to `CPrint`