### PR TITLE
Remove date/time from log statements

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ Value of color can be %s
 }
 
 func main() {
+	log.SetFlags(0)
 	ccatCmd := &ccatCmd{
 		ColorCodes: make(mapValue),
 	}


### PR DESCRIPTION
Resetting logger flags (default log.Ldate|log.Ltime) as it shows datetime
output for cat.

This fixes #53.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>