### PR TITLE
Supports apple darwin/arm64 architectures

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -31,7 +31,7 @@ compress() {
   ls -all
 }
 
-OSARCH="darwin/amd64 linux/amd64 linux/386 windows/amd64 windows/386"
+OSARCH="darwin/arm64 darwin/amd64 linux/amd64 linux/386 windows/amd64 windows/386"
 
 echo "Packaging ccat $(version)"
 echo


### PR DESCRIPTION
This requires go version `go1.16beta1 darwin/arm64` or higher

I am very new to building go binaries, is there anything I would need to do at the package level to enforce a minimum version of go for building? 

And is there anything I would need to do within the repo to handle versioning of ccat itself? 