### PR TITLE
Update install from source command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Prerequisites:
 - [Go](https://golang.org/doc/install) 1.4+
 
 ```
-$ go get -u github.com/owenthereal/ccat
+$ go install github.com/owenthereal/ccat@latest
 ```
 
 ## Completion (ZSH Only)


### PR DESCRIPTION
Go recently changed the functionality of "go get", so now "go install" is the preferred method.